### PR TITLE
Link for documentation card images

### DIFF
--- a/src/common/CardSection.js
+++ b/src/common/CardSection.js
@@ -6,8 +6,8 @@ import tw from 'tailwind-styled-components'
 
 const CardContent = tw(GridSection)`h-full`
 
-const CardSection = ({ to, title, image, className, children }) => {
-  let titleComp
+const CardSection = ({ to, title, image, className, children, external }) => {
+  let titleComp, imageComp, externalComp
 
   if (to.startsWith('http')) {
     titleComp = (
@@ -15,8 +15,29 @@ const CardSection = ({ to, title, image, className, children }) => {
         {title}
       </a>
     )
+    imageComp = (
+      <a href={to} target={'_blank'} rel='noreferrer'>
+        <img src={image} alt={'Section icon'} />
+      </a>
+    )
   } else {
     titleComp = <HashLink to={to}> {title} </HashLink>
+    imageComp = (
+      <HashLink to={to}>
+        {' '}
+        <img src={image} alt={'Section icon'} />{' '}
+      </HashLink>
+    )
+  }
+
+  if (external && external.startsWith('http')) {
+    externalComp = (
+      <small>
+        <a href={external} target={'_blank'} rel='noreferrer'>
+          (external link)
+        </a>
+      </small>
+    )
   }
 
   return (
@@ -29,10 +50,11 @@ const CardSection = ({ to, title, image, className, children }) => {
           <CardContent>
             <div className={'flex flex-col items-center space-y-2 h-full'}>
               <GridSectionTitleCentered>{titleComp}</GridSectionTitleCentered>
-
-              <img src={image} alt={'Section icon'} />
-
-              <p align='center' className={'py-4'}>
+              {imageComp}
+              <p align='center' className={'py-0'}>
+                {externalComp}
+              </p>
+              <p align='center' className={'py-2'}>
                 {children}
               </p>
             </div>
@@ -49,6 +71,7 @@ CardSection.propTypes = {
   image: PropTypes.string,
   className: PropTypes.string,
   children: PropTypes.any,
+  external: PropTypes.string,
 }
 
 export default CardSection

--- a/src/common/CardSection.js
+++ b/src/common/CardSection.js
@@ -24,8 +24,7 @@ const CardSection = ({ to, title, image, className, children, external }) => {
     titleComp = <HashLink to={to}> {title} </HashLink>
     imageComp = (
       <HashLink to={to}>
-        {' '}
-        <img src={image} alt={'Section icon'} />{' '}
+        <img src={image} alt={'Section icon'} />
       </HashLink>
     )
   }

--- a/src/pages/Documentation.js
+++ b/src/pages/Documentation.js
@@ -33,20 +33,23 @@ const Documentation = () => {
                 <CardSection
                   title={'UPBGE Current Manual'}
                   to={'/docs/latest/manual/index.html'}
-                  image={upbge_manual}>
+                  image={upbge_manual}
+                  external={'https://upbge.org/docs/latest/manual/index.html'}>
                   Learn about the UPBGE game-engine specific contents,
                   including: Game Logic, Physics, Python Programming, and more
                 </CardSection>
                 <CardSection
                   title={'UPBGE & Blender Python API'}
                   to={'/docs/latest/api/index.html'}
-                  image={upbge_python_api}>
+                  image={upbge_python_api}
+                  external={'https://upbge.org/docs/latest/api/index.html'}>
                   Unified Python API for UPBGE current and Blender
                 </CardSection>
                 <CardSection
                   title={'Former UPBGE 0.2.5 Manual & API'}
                   to={'/docs/v0.2.5/index.html'}
-                  image={upbge_old_manual}>
+                  image={upbge_old_manual}
+                  external={'https://upbge.org/docs/v0.2.5/index.html'}>
                   Unified Manual and Python API for former UPBGE 0.2.5 release
                 </CardSection>
                 <CardSection


### PR DESCRIPTION
This change introduces a link in the images of SectionCard.

Addittionally, it also introduces an external link option. This option is used, in this case, to can open the documentation using standard readthedocs format. 

Currently, there are several bugs with the behaviour of the embedded documentation (links with double slash, inoperative after search, etc, I will open the issues separately). This external link can be used as a "back-up working" link or even a link for people that like the standard readthedocs format more.

A screencapture to see better the mock-up
![image](https://user-images.githubusercontent.com/1015605/146879343-5c26d7e1-cd8c-4017-ade5-16785fd4136d.png)
