### PR TITLE
Implement legacy download links + UI overhaul

### DIFF
--- a/src/pages/Download.js
+++ b/src/pages/Download.js
@@ -24,7 +24,7 @@ if (isWindows || isWinPhone) {
 const TabSection = tw(GridSection)`flex flex-col gap-6`
 
 const Download = () => {
-  //const [tabIndex, setTabIndex] = useState(0)
+  const [tabIndex, setTabIndex] = useState(0)
 
   return (
     <div className={'p-10'}>
@@ -32,20 +32,24 @@ const Download = () => {
         <WideHSection>
           <div className={'flex flex-col items-center pt-4'}>
             <img src={logo_name} alt={'UPBGE Logo with name'} />
-            <br />
-            <SectionTitle>Version Info</SectionTitle>
-            <TabSection>
-              <div>
-              <p><strong>UPBGE 0.3.0</strong>&nbsp;is based on stable&nbsp;<strong>Blender 3.0</strong>&nbsp;source</p>
-              <p><strong>UPBGE 0.3+</strong>&nbsp;is based on experimental&nbsp;<strong>Blender</strong>&nbsp;source</p>
-              <p><strong>UPBGE 0.2.5b</strong>&nbsp;is based on legacy&nbsp;<strong>Blender 2.79.7</strong>&nbsp;source</p>
-              </div>
+              <br />
+              <SectionTitle>Stable Release</SectionTitle>
+              <p>Version UPBGE 0.3</p>
+              <p>Released 4 December 2021</p>
+              <p>&nbsp;</p>
+              <TabSection>
+                <div>
+                  <BulletListInside>
+                    <li><strong>UPBGE 0.3+</strong>&nbsp;is based on latest&nbsp;<strong>Blender</strong>&nbsp;source</li>
+                    <li><strong>UPBGE 0.2.5b</strong>&nbsp;is based on legacy&nbsp;<strong>Blender 2.7.9.7</strong>&nbsp;source</li>
+                  </BulletListInside>
+                </div>
             </TabSection>
           </div>
           <div>
             <Tabs forceRenderTabPanel defaultIndex={0}>
               <TabList>
-                <Tab>UPBGE 0.3.x</Tab>
+                <Tab>UPBGE 0.3+</Tab>
                 <Tab>UPBGE 0.2.x</Tab>
               </TabList>
               <TabPanel>
@@ -73,16 +77,18 @@ const Download = () => {
                           target={'_blank'}>Download (64-bit)
                         </Button>
                         </div>
+                        <hr />
                         <div>
                           <SectionTitle>Requirements</SectionTitle>
                           <BulletListInside>
-                            <li>64-bit quad core CPU with SSE2 support</li>
-                            <li>8 GB RAM</li>
-                            <li>Full HD display</li>
-                            <li>Mouse, trackpad or pen+tablet</li>
-                            <li>Graphics card with 2 GB RAM, OpenGL 4.3</li>
+                            <li><strong>CPU:</strong> 64-bit quad core</li>
+                            <li className="list-none ml-4">with SSE2 support minimum</li>
+                            <li><strong>GPU:</strong> 2GB VRAM minimum</li>
+                            <li><strong>RAM:</strong> 8GB minimum</li>
+                            <li><strong>OpenGL:</strong> 4.3+ minimum</li>
                           </BulletListInside>
                         </div>
+                        <hr />
                         <div>
                           <SectionTitle>Note</SectionTitle>
                           <BulletListInside>
@@ -93,6 +99,7 @@ const Download = () => {
                             <li>64-bit builds don't run on 32-bit systems</li>
                           </BulletListInside>
                         </div>
+                        <hr />
                         <div>
                           <SectionTitle>Misc Downloads</SectionTitle>
                           <BulletListInside>
@@ -124,16 +131,18 @@ const Download = () => {
                           target={'_blank'}>Unavailable
                         </Button>
                         </div>
+                        <hr />
                         <div>
                           <SectionTitle>Requirements</SectionTitle>
                           <BulletListInside>
-                            <li>64-bit quad core CPU with SSE2 support</li>
-                            <li>8 GB RAM</li>
-                            <li>Full HD display</li>
-                            <li>Mouse, trackpad or pen+tablet</li>
-                            <li>Graphics card with 2 GB RAM, OpenGL 4.3</li>
+                            <li><strong>CPU:</strong> 64-bit quad core</li>
+                            <li className="list-none ml-4">with SSE2 support minimum</li>
+                            <li><strong>GPU:</strong> 2GB VRAM minimum</li>
+                            <li><strong>RAM:</strong> 8GB minimum</li>
+                            <li><strong>OpenGL:</strong> 4.3+ minimum</li>
                           </BulletListInside>
                         </div>
+                        <hr />
                         <div>
                           <SectionTitle>Note</SectionTitle>
                           <BulletListInside>
@@ -146,6 +155,7 @@ const Download = () => {
                             <li>64-bit builds don't run on 32-bit systems</li>
                           </BulletListInside>
                         </div>
+                        <hr />
                         <div>
                           <SectionTitle>Misc Downloads</SectionTitle>
                           <BulletListInside>
@@ -177,16 +187,18 @@ const Download = () => {
                           target={'_blank'}>Download (64-bit)
                         </Button>
                         </div>
+                        <hr />
                         <div>
                           <SectionTitle>Requirements</SectionTitle>
                           <BulletListInside>
-                            <li>64-bit quad core CPU with SSE2 support</li>
-                            <li>8 GB RAM</li>
-                            <li>Full HD display</li>
-                            <li>Mouse, trackpad or pen+tablet</li>
-                            <li>Graphics card with 2 GB RAM, OpenGL 4.3</li>
+                            <li><strong>CPU:</strong> 64-bit quad core</li>
+                            <li className="list-none ml-4">with SSE2 support minimum</li>
+                            <li><strong>GPU:</strong> 2GB VRAM minimum</li>
+                            <li><strong>RAM:</strong> 8GB minimum</li>
+                            <li><strong>OpenGL:</strong> 4.3+ minimum</li>
                           </BulletListInside>
                         </div>
+                        <hr />
                         <div>
                           <SectionTitle>Note</SectionTitle>
                           <BulletListInside>
@@ -198,6 +210,7 @@ const Download = () => {
                             <li className="list-none ml-4">or a similar application</li>
                           </BulletListInside>
                         </div>
+                        <hr />
                         <div>
                           <SectionTitle>Misc Downloads</SectionTitle>
                           <BulletListInside>
@@ -216,7 +229,7 @@ const Download = () => {
                     <TabPanel>
                       <TabSection>
                         <div>
-                          <SectionTitle>UPBGE 0.3 Experimental</SectionTitle>
+                          <SectionTitle>UPBGE 0.3+ Experimental</SectionTitle>
                           <Button
                             href={'https://mega.nz/folder/t9EEFSaS#JPiOPSInCZyU-SW_-rhEOQ'}
                             target={'_blank'}>Browse or download
@@ -229,12 +242,14 @@ const Download = () => {
                             target={'_blank'}>Browse or download
                           </Button>
                         </div>
+                        <hr />
                         <div>
                           <SectionTitle>Requirements</SectionTitle>
                           <BulletListInside>
                             <li>Check in corresponding platform tabs</li>
                           </BulletListInside>
                         </div>
+                        <hr />
                         <div>
                           <SectionTitle>Note</SectionTitle>
                           <BulletListInside>
@@ -259,7 +274,7 @@ const Download = () => {
                     <TabPanel>
                       <TabSection>
                         <div>
-                          <SectionTitle>Windows 8.1, 10, & 11</SectionTitle>
+                          <SectionTitle>Windows 7, 8.1, 10, & 11</SectionTitle>
                           <Button
                             href={'https://github.com/UPBGE/upbge/releases/download/v0.2.5b/UPBGEv0.2.5b-b2.79Windows64.7z'}
                             target={'_blank'}>Download (64-bit)
@@ -271,14 +286,16 @@ const Download = () => {
                           target={'_blank'}>Download (32-bit)
                         </Button>
                         </div>
+                        <hr />
                         <div>
                           <SectionTitle>Requirements</SectionTitle>
                           <BulletListInside>
                             <li>Blender 2.79 runs on all systems that support</li>
                             <li className="list-none ml-4">OpenGL 2.1 and above, with recent</li>
-                            <li className="list-none ml-4">graphics drivers. For macOS, version 10.9 and later are supported.</li>
+                            <li className="list-none ml-4">graphics drivers</li>
                           </BulletListInside>
                         </div>
+                        <hr />
                         <div>
                           <SectionTitle>Note</SectionTitle>
                           <BulletListInside>
@@ -289,6 +306,7 @@ const Download = () => {
                             <li>64-bit builds don't run on 32-bit systems</li>
                           </BulletListInside>
                         </div>
+                        <hr />
                         <div>
                           <SectionTitle>Misc Downloads</SectionTitle>
                           <BulletListInside>
@@ -313,21 +331,16 @@ const Download = () => {
                             target={'_blank'}>Download (64-bit)
                           </Button>
                         </div>
-                        <div>
-                        <SectionTitle>Linux aarch64 (coming soon)</SectionTitle>
-                        <Button
-                          href={'#'}
-                          target={'_blank'}>Unavailable
-                        </Button>
-                        </div>
+                        <hr />
                         <div>
                           <SectionTitle>Requirements</SectionTitle>
                           <BulletListInside>
                             <li>Blender 2.79 runs on all systems that support</li>
                             <li className="list-none ml-4">OpenGL 2.1 and above, with recent</li>
-                            <li className="list-none ml-4">graphics drivers. For macOS, version 10.9 and later are supported.</li>
+                            <li className="list-none ml-4">graphics drivers</li>
                           </BulletListInside>
                         </div>
+                        <hr />
                         <div>
                           <SectionTitle>Note</SectionTitle>
                           <BulletListInside>
@@ -340,6 +353,7 @@ const Download = () => {
                             <li>64-bit builds don't run on 32-bit systems</li>
                           </BulletListInside>
                         </div>
+                        <hr />
                         <div>
                           <SectionTitle>Misc Downloads</SectionTitle>
                           <BulletListInside>
@@ -364,14 +378,16 @@ const Download = () => {
                             target={'_blank'}>Download (64-bit)
                           </Button>
                         </div>
+                        <hr />
                         <div>
                           <SectionTitle>Requirements</SectionTitle>
                           <BulletListInside>
                             <li>Blender 2.79 runs on all systems that support</li>
                             <li className="list-none ml-4">OpenGL 2.1 and above, with recent</li>
-                            <li className="list-none ml-4">graphics drivers. For macOS, version 10.9 and later are supported.</li>
+                            <li className="list-none ml-4">graphics drivers</li>
                           </BulletListInside>
                         </div>
+                        <hr />
                         <div>
                           <SectionTitle>Note</SectionTitle>
                           <BulletListInside>
@@ -383,6 +399,7 @@ const Download = () => {
                             <li className="list-none ml-4">or a similar application</li>
                           </BulletListInside>
                         </div>
+                        <hr />
                         <div>
                           <SectionTitle>Misc Downloads</SectionTitle>
                           <BulletListInside>
@@ -407,12 +424,14 @@ const Download = () => {
                             target={'_blank'}>Browse or download
                           </Button>
                         </div>
+                        <hr />
                         <div>
                           <SectionTitle>Requirements</SectionTitle>
                           <BulletListInside>
                             <li>Check in corresponding platform tabs</li>
                           </BulletListInside>
                         </div>
+                        <hr />
                         <div>
                           <SectionTitle>Note</SectionTitle>
                           <BulletListInside>

--- a/src/pages/Download.js
+++ b/src/pages/Download.js
@@ -24,7 +24,7 @@ if (isWindows || isWinPhone) {
 const TabSection = tw(GridSection)`flex flex-col gap-6`
 
 const Download = () => {
-  const [tabIndex, setTabIndex] = useState(sta)
+  //const [tabIndex, setTabIndex] = useState(0)
 
   return (
     <div className={'p-10'}>
@@ -33,299 +33,397 @@ const Download = () => {
           <div className={'flex flex-col items-center pt-4'}>
             <img src={logo_name} alt={'UPBGE Logo with name'} />
             <br />
-            <SectionTitle>Stable Release Version 0.3</SectionTitle>
-            <p>Released 4 December 2021</p>
+            <SectionTitle>Version Info</SectionTitle>
+            <TabSection>
+              <div>
+              <p><strong>UPBGE 0.3.0</strong>&nbsp;is based on stable&nbsp;<strong>Blender 3.0</strong>&nbsp;source</p>
+              <p><strong>UPBGE 0.3+</strong>&nbsp;is based on experimental&nbsp;<strong>Blender</strong>&nbsp;source</p>
+              <p><strong>UPBGE 0.2.5b</strong>&nbsp;is based on legacy&nbsp;<strong>Blender 2.79.7</strong>&nbsp;source</p>
+              </div>
+            </TabSection>
           </div>
           <div>
-            <Tabs selectedIndex={tabIndex} onSelect={setTabIndex}>
+            <Tabs forceRenderTabPanel defaultIndex={0}>
               <TabList>
-                <Tab>Windows</Tab>
-                <Tab>Linux</Tab>
-                <Tab>Mac OS</Tab>
-                <Tab>Experimental</Tab>
+                <Tab>UPBGE 0.3.x</Tab>
+                <Tab>UPBGE 0.2.x</Tab>
               </TabList>
               <TabPanel>
-                <TabSection>
-                  <div>
-                    <SectionTitle>For Windows 8.1, 10 and 11</SectionTitle>
-                    <Button
-                      className={'mt-2'}
-                      href={
-                        'https://github.com/UPBGE/upbge/releases/download/v0.30/UPBGE-0.30-windows-x86_64.7z'
-                      }
-                      target={'_blank'}>
-                      Download UPBGE 0.30.0 (64-bit)
-                    </Button>
-                  </div>
-                  <div>
-                    <SectionTitle>For Windows 7</SectionTitle>
-                    <Button
-                      className={'mt-2'}
-                      href={
-                        'https://github.com/UPBGE/upbge/releases/download/v0.30/UPBGE-0.30-windows7-x86_64.7z'
-                      }
-                      target={'_blank'}>
-                      Download UPBGE 0.30.0 (64-bit)
-                    </Button>
-                  </div>
-                  <div>
-                    <p>NOTE:</p>
-                    <BulletListInside>
-                      <li>64-bit builds don't run on 32-bit systems</li>
-		              <li>
-                        7z extension can be extracted with&nbsp;
-                        <a
-                        href='https://www.7-zip.org/'
-                        target={'_blank'}
-                        rel='noreferrer'>
-                        7zip
-                        </a>&nbsp;
-		              </li>
-                      <li className="list-none ml-4">or a similar application&nbsp;</li>
-                    </BulletListInside>
-                  </div>
-                </TabSection>
-                <br />
-                <TabSection>
-                  <div>
-                    <SectionTitle>Requirements</SectionTitle>
-                    <BulletListInside>
-                      <li>CPU: 64-bit, Dual-Core 2GHz CPU with SSE2 support</li>
-                      <li>RAM: minimum 2GB</li>
-                      <li>Display: 1280×768</li>
-                      <li>GPU: minimum 1GB VRAM; OpenGL 3.3+</li>
-                      <li>Hard Drive: minimum 500MB free space</li>
-                    </BulletListInside>
-                  </div>
-                </TabSection>
-                <br />
-                <TabSection>
-                  <div>
-                    <SectionTitle>Other links</SectionTitle>
-                    <BulletListInside>
-                      <li>
-                        Alternative download link&nbsp;
-                        <a
-                          href='https://mega.nz/folder/RsFSSZjA#rTNA_4nBbLp0BSTX9-DqSA'
-                          target={'_blank'}
-                          rel='noreferrer'>
-                          (MEGA)
-                        </a>
-                      </li>
-                      <li>
-                        Download old UPBGE versions from&nbsp;
-                        <a
-                          href='https://github.com/UPBGE/upbge/releases'
-                          target={'_blank'}
-                          rel='noreferrer'>
-                          here
-                        </a>&nbsp;
-                        or&nbsp;
-                        <a
-                          href='https://mega.nz/folder/k9MW1KiZ#UOKzjh3IQ0GEgjQ6GUc7ug'
-                          target={'_blank'}
-                          rel='noreferrer'>
-                          here
-                        </a>
-                      </li>
-                    </BulletListInside>
-                  </div>
-                </TabSection>
+                <Tabs forceRenderTabPanel>
+                  <TabSection>
+                    <TabList>
+                      <Tab>Windows</Tab>
+                      <Tab>Linux</Tab>
+                      <Tab>macOS</Tab>
+                      <Tab>Experimental</Tab>
+                    </TabList>
+                    <TabPanel>
+                      <TabSection>
+                        <div>
+                          <SectionTitle>Windows 8.1, 10, & 11</SectionTitle>
+                          <Button
+                            href={'https://github.com/UPBGE/upbge/releases/download/v0.30/UPBGE-0.30-windows-x86_64.7z'}
+                            target={'_blank'}>Download (64-bit)
+                          </Button>
+                        </div>
+                        <div>
+                        <SectionTitle>Windows 7</SectionTitle>
+                        <Button
+                          href={'https://github.com/UPBGE/upbge/releases/download/v0.30/UPBGE-0.30-windows7-x86_64.7z'}
+                          target={'_blank'}>Download (64-bit)
+                        </Button>
+                        </div>
+                        <div>
+                          <SectionTitle>Requirements</SectionTitle>
+                          <BulletListInside>
+                            <li>64-bit quad core CPU with SSE2 support</li>
+                            <li>8 GB RAM</li>
+                            <li>Full HD display</li>
+                            <li>Mouse, trackpad or pen+tablet</li>
+                            <li>Graphics card with 2 GB RAM, OpenGL 4.3</li>
+                          </BulletListInside>
+                        </div>
+                        <div>
+                          <SectionTitle>Note</SectionTitle>
+                          <BulletListInside>
+                            <li>7z extension can be extracted with&nbsp;
+                              <a href='https://www.7-zip.org/' target={'_blank'} rel='noreferrer'><strong>7zip</strong></a>
+                            </li>
+                            <li className="list-none ml-4">or a similar application</li>
+                            <li>64-bit builds don't run on 32-bit systems</li>
+                          </BulletListInside>
+                        </div>
+                        <div>
+                          <SectionTitle>Misc Downloads</SectionTitle>
+                          <BulletListInside>
+                            <li>Alternative download links:
+                              <a href='https://mega.nz/folder/RsFSSZjA#rTNA_4nBbLp0BSTX9-DqSA' target={'_blank'} rel='noreferrer'><strong>&nbsp;here</strong></a>
+                            </li>
+                            <li>Download older UPBGE versions:</li>
+                            <li className="list-none ml-4">
+                              <a href='https://github.com/UPBGE/upbge/releases' target={'_blank'} rel='noreferrer'><strong>&nbsp;here&nbsp;</strong></a>or
+                              <a href='https://mega.nz/folder/k9MW1KiZ#UOKzjh3IQ0GEgjQ6GUc7ug' target={'_blank'} rel='noreferrer'><strong>&nbsp;here&nbsp;</strong></a>
+                            </li>
+                          </BulletListInside>
+                        </div>
+                      </TabSection>
+                    </TabPanel>
+                    <TabPanel>
+                      <TabSection>
+                        <div>
+                          <SectionTitle>Linux x64</SectionTitle>
+                          <Button
+                            href={'https://github.com/UPBGE/upbge/releases/download/v0.30/UPBGE-0.30-linux-x86_64.tar.xz'}
+                            target={'_blank'}>Download (64-bit)
+                          </Button>
+                        </div>
+                        <div>
+                        <SectionTitle>Linux aarch64 (coming soon)</SectionTitle>
+                        <Button
+                          href={'#'}
+                          target={'_blank'}>Unavailable
+                        </Button>
+                        </div>
+                        <div>
+                          <SectionTitle>Requirements</SectionTitle>
+                          <BulletListInside>
+                            <li>64-bit quad core CPU with SSE2 support</li>
+                            <li>8 GB RAM</li>
+                            <li>Full HD display</li>
+                            <li>Mouse, trackpad or pen+tablet</li>
+                            <li>Graphics card with 2 GB RAM, OpenGL 4.3</li>
+                          </BulletListInside>
+                        </div>
+                        <div>
+                          <SectionTitle>Note</SectionTitle>
+                          <BulletListInside>
+                            <li>Builds are compiled from a CentOS 7</li>
+                            <li className="list-none ml-4">distribution&nbsp;</li>
+                            <li>xz extension can be extracted with&nbsp;
+                              <a href='https://www.7-zip.org/' target={'_blank'} rel='noreferrer'><strong>7zip</strong></a>
+                            </li>
+                            <li className="list-none ml-4">or a similar application</li>
+                            <li>64-bit builds don't run on 32-bit systems</li>
+                          </BulletListInside>
+                        </div>
+                        <div>
+                          <SectionTitle>Misc Downloads</SectionTitle>
+                          <BulletListInside>
+                            <li>Alternative download links:
+                              <a href='https://mega.nz/folder/RsFSSZjA#rTNA_4nBbLp0BSTX9-DqSA' target={'_blank'} rel='noreferrer'><strong>&nbsp;here</strong></a>
+                            </li>
+                            <li>Download older UPBGE versions:</li>
+                            <li className="list-none ml-4">
+                              <a href='https://github.com/UPBGE/upbge/releases' target={'_blank'} rel='noreferrer'><strong>&nbsp;here&nbsp;</strong></a>or
+                              <a href='https://mega.nz/folder/k9MW1KiZ#UOKzjh3IQ0GEgjQ6GUc7ug' target={'_blank'} rel='noreferrer'><strong>&nbsp;here&nbsp;</strong></a>
+                            </li>
+                          </BulletListInside>
+                        </div>
+                      </TabSection>
+                    </TabPanel>
+                    <TabPanel>
+                      <TabSection>
+                        <div>
+                          <SectionTitle>macOS Intel (10.13+)</SectionTitle>
+                          <Button
+                            href={'https://github.com/UPBGE/upbge/releases/download/v0.30/UPBGE-0.30-macOS-x86_64.dmg'}
+                            target={'_blank'}>Download (64-bit)
+                          </Button>
+                        </div>
+                        <div>
+                        <SectionTitle>macOS Apple Silicon (11.0+)</SectionTitle>
+                        <Button
+                          href={'https://github.com/UPBGE/upbge/releases/download/v0.30/UPBGE-0.30-macOS-arm64.dmg'}
+                          target={'_blank'}>Download (64-bit)
+                        </Button>
+                        </div>
+                        <div>
+                          <SectionTitle>Requirements</SectionTitle>
+                          <BulletListInside>
+                            <li>64-bit quad core CPU with SSE2 support</li>
+                            <li>8 GB RAM</li>
+                            <li>Full HD display</li>
+                            <li>Mouse, trackpad or pen+tablet</li>
+                            <li>Graphics card with 2 GB RAM, OpenGL 4.3</li>
+                          </BulletListInside>
+                        </div>
+                        <div>
+                          <SectionTitle>Note</SectionTitle>
+                          <BulletListInside>
+                            <li>macOS Intel requires version 10+</li>
+                            <li>macOS Apple Silicon requires version 11+</li>
+                            <li>dmg extension can be extracted with&nbsp;
+                              <a href='https://www.7-zip.org/' target={'_blank'} rel='noreferrer'><strong>7zip</strong></a>
+                            </li>
+                            <li className="list-none ml-4">or a similar application</li>
+                          </BulletListInside>
+                        </div>
+                        <div>
+                          <SectionTitle>Misc Downloads</SectionTitle>
+                          <BulletListInside>
+                            <li>Alternative download links:
+                              <a href='https://mega.nz/folder/RsFSSZjA#rTNA_4nBbLp0BSTX9-DqSA' target={'_blank'} rel='noreferrer'><strong>&nbsp;here</strong></a>
+                            </li>
+                            <li>Download older UPBGE versions:</li>
+                            <li className="list-none ml-4">
+                              <a href='https://github.com/UPBGE/upbge/releases' target={'_blank'} rel='noreferrer'><strong>&nbsp;here&nbsp;</strong></a>or
+                              <a href='https://mega.nz/folder/k9MW1KiZ#UOKzjh3IQ0GEgjQ6GUc7ug' target={'_blank'} rel='noreferrer'><strong>&nbsp;here&nbsp;</strong></a>
+                            </li>
+                          </BulletListInside>
+                        </div>
+                      </TabSection>
+                    </TabPanel>
+                    <TabPanel>
+                      <TabSection>
+                        <div>
+                          <SectionTitle>UPBGE 0.3 Experimental</SectionTitle>
+                          <Button
+                            href={'https://mega.nz/folder/t9EEFSaS#JPiOPSInCZyU-SW_-rhEOQ'}
+                            target={'_blank'}>Browse or download
+                          </Button>
+                        </div>
+                        <div>
+                          <SectionTitle>Misc Experimental</SectionTitle>
+                          <Button
+                            href={'https://mega.nz/folder/k9MW1KiZ#UOKzjh3IQ0GEgjQ6GUc7ug/folder/QsVFVIRb'}
+                            target={'_blank'}>Browse or download
+                          </Button>
+                        </div>
+                        <div>
+                          <SectionTitle>Requirements</SectionTitle>
+                          <BulletListInside>
+                            <li>Check in corresponding platform tabs</li>
+                          </BulletListInside>
+                        </div>
+                        <div>
+                          <SectionTitle>Note</SectionTitle>
+                          <BulletListInside>
+                            <li>The repository is hosted inside a external</li>
+                            <li className="list-none ml-4">MEGA folder</li>
+                          </BulletListInside>
+                        </div>
+                      </TabSection>
+                    </TabPanel>
+                  </TabSection>
+                </Tabs>
               </TabPanel>
               <TabPanel>
-                <TabSection>
-                  <div>
-                    <SectionTitle>Linux x64</SectionTitle>
-                    <Button
-                      className={'mt-2'}
-                      href={
-                        'https://github.com/UPBGE/upbge/releases/download/v0.30/UPBGE-0.30-linux-x86_64.tar.xz'
-                      }
-                      target={'_blank'}>
-                      Download UPBGE 0.30.0 (64-bit)
-                    </Button>
-                  </div>
-                  <div>
-                    <SectionTitle>
-                      Linux aarch64 (not available yet)
-                    </SectionTitle>
-                    <Button
-                      className={'mt-2'}
-                      href={
-                        'https://github.com/UPBGE/upbge/releases/download/v0.30/UPBGE-0.30-linux-aarch64.tar.xz'
-                      }
-                      target={'_blank'}>
-                      Download UPBGE 0.30.0 (arm 64-bit)
-                    </Button>
-                  </div>
-                  <div>
-                    <p>NOTE:</p>
-                    <BulletListInside>
-                      <li>64-bit builds don't run on 32-bit systems</li>
-                      <li>Builds are compiled from a CentOS 7 distribution</li>
-                    </BulletListInside>
-                  </div>
-                </TabSection>
-                <br />
-                <TabSection>
-                  <div>
-                    <SectionTitle>Requirements</SectionTitle>
-                    <BulletListInside>
-                      <li>glibc 2.17+</li>
-                      <li>CPU: 64-bit, Dual-Core 2GHz CPU with SSE2 support</li>
-                      <li>RAM: minimum 2GB</li>
-                      <li>Display: 1280×768</li>
-                      <li>GPU: minimum 1GB VRAM; OpenGL 3.3+</li>
-                      <li>Hard Drive: minimum 500MB free space</li>
-                    </BulletListInside>
-                  </div>
-                </TabSection>
-                <br />
-                <TabSection>
-                  <div>
-                    <SectionTitle>Other links</SectionTitle>
-                    <BulletListInside>
-                      <li>
-                        Alternative download link&nbsp;
-                        <a
-                          href='https://mega.nz/folder/RsFSSZjA#rTNA_4nBbLp0BSTX9-DqSA'
-                          target={'_blank'}
-                          rel='noreferrer'>
-                          (MEGA)
-                        </a>
-                      </li>
-                      <li>
-                        Download old UPBGE versions from&nbsp;
-                        <a
-                          href='https://github.com/UPBGE/upbge/releases'
-                          target={'_blank'}
-                          rel='noreferrer'>
-                          here
-                        </a>&nbsp;
-                        or&nbsp;
-                        <a
-                          href='https://mega.nz/folder/k9MW1KiZ#UOKzjh3IQ0GEgjQ6GUc7ug'
-                          target={'_blank'}
-                          rel='noreferrer'>
-                          here
-                        </a>
-                      </li>
-                    </BulletListInside>
-                  </div>
-                </TabSection>
-              </TabPanel>
-              <TabPanel>
-                <TabSection>
-                  <div>
-                    <SectionTitle>macOS Intel</SectionTitle>
-                    <Button
-                      className={'mt-2'}
-                      href={
-                        'https://github.com/UPBGE/upbge/releases/download/v0.30/UPBGE-0.30-macOS-x86_64.dmg'
-                      }
-                      target={'_blank'}>
-                      Download UPBGE 0.30.0 (64-bit)
-                    </Button>
-                  </div>
-                  <div>
-                    <SectionTitle>macOS Apple Silicon</SectionTitle>
-                    <Button
-                      className={'mt-2'}
-                      href={
-                        'https://github.com/UPBGE/upbge/releases/download/v0.30/UPBGE-0.30-macOS-arm64.dmg'
-                      }
-                      target={'_blank'}>
-                      Download UPBGE 0.30.0 (64-bit)
-                    </Button>
-                  </div>
-                  <div>
-                    <p>NOTE:</p>
-                    <BulletListInside>
-                      <li>macOS Intel requires version 10+</li>
-                      <li>macOS Apple Silicon requires version 11+</li>
-                    </BulletListInside>
-                  </div>
-                </TabSection>
-                <br />
-                <TabSection>
-                  <div>
-                    <SectionTitle>Requirements</SectionTitle>
-                    <BulletListInside>
-                      <li>CPU: 64-bit, Dual-Core 2GHz CPU with SSE2 support</li>
-                      <li>RAM: minimum 2GB</li>
-                      <li>Display: 1280×768</li>
-                      <li>GPU: minimum 1GB VRAM; OpenGL 3.3+</li>
-                      <li>Hard Drive: minimum 500MB free space</li>
-                    </BulletListInside>
-                  </div>
-                </TabSection>
-                <br />
-                <TabSection>
-                  <div>
-                    <SectionTitle>Other links</SectionTitle>
-                    <BulletListInside>
-                      <li>
-                        Alternative download link&nbsp;
-                        <a
-                          href='https://mega.nz/folder/RsFSSZjA#rTNA_4nBbLp0BSTX9-DqSA'
-                          target={'_blank'}
-                          rel='noreferrer'>
-                          (MEGA)
-                        </a>
-                      </li>
-                      <li>
-                        Download old UPBGE versions from&nbsp;
-                        <a
-                          href='https://github.com/UPBGE/upbge/releases'
-                          target={'_blank'}
-                          rel='noreferrer'>
-                          here
-                        </a>&nbsp;
-                        or&nbsp;
-                        <a
-                          href='https://mega.nz/folder/k9MW1KiZ#UOKzjh3IQ0GEgjQ6GUc7ug'
-                          target={'_blank'}
-                          rel='noreferrer'>
-                          here
-                        </a>
-                      </li>
-                    </BulletListInside>
-                  </div>
-                </TabSection>
-              </TabPanel>
-              <TabPanel>
-                <TabSection>
-                  <div>
-                    <SectionTitle>Experimental Builds</SectionTitle>
-                    <Button
-                      className={'mt-2'}
-                      href={
-                        'https://mega.nz/folder/t9EEFSaS#JPiOPSInCZyU-SW_-rhEOQ'
-                      }
-                      target={'_blank'}>
-                      Browse or download
-                    </Button>
-                  </div>
-                  <div>
-                    <p>NOTE:</p>
-                    <BulletListInside>
-                      <li>The repository is hosted inside a MEGA folder</li>
-                    </BulletListInside>
-                  </div>
-                </TabSection>
-                <br />
-                <TabSection>
-                  <div>
-                    <SectionTitle>Requirements</SectionTitle>
-                    <BulletListInside>
-                      <li>CPU: 64-bit, Dual-Core 2GHz CPU with SSE2 support</li>
-                      <li>RAM: minimum 2GB</li>
-                      <li>Display: 1280×768</li>
-                      <li>GPU: minimum 1GB VRAM; OpenGL 3.3+</li>
-                      <li>Hard Drive: minimum 500MB free space</li>
-                    </BulletListInside>
-                  </div>
-                </TabSection>
+                <Tabs forceRenderTabPanel>
+                  <TabSection>
+                    <TabList>
+                      <Tab>Windows</Tab>
+                      <Tab>Linux</Tab>
+                      <Tab>macOS</Tab>
+                      <Tab>Experimental</Tab>
+                    </TabList>
+                    <TabPanel>
+                      <TabSection>
+                        <div>
+                          <SectionTitle>Windows 8.1, 10, & 11</SectionTitle>
+                          <Button
+                            href={'https://github.com/UPBGE/upbge/releases/download/v0.2.5b/UPBGEv0.2.5b-b2.79Windows64.7z'}
+                            target={'_blank'}>Download (64-bit)
+                          </Button>
+                        </div>
+                        <div>
+                        <Button
+                          href={'https://github.com/UPBGE/upbge/releases/download/v0.2.5b/UPBGEv0.2.5b-b2.79Windows32.7z'}
+                          target={'_blank'}>Download (32-bit)
+                        </Button>
+                        </div>
+                        <div>
+                          <SectionTitle>Requirements</SectionTitle>
+                          <BulletListInside>
+                            <li>Blender 2.79 runs on all systems that support</li>
+                            <li className="list-none ml-4">OpenGL 2.1 and above, with recent</li>
+                            <li className="list-none ml-4">graphics drivers. For macOS, version 10.9 and later are supported.</li>
+                          </BulletListInside>
+                        </div>
+                        <div>
+                          <SectionTitle>Note</SectionTitle>
+                          <BulletListInside>
+                            <li>7z extension can be extracted with&nbsp;
+                              <a href='https://www.7-zip.org/' target={'_blank'} rel='noreferrer'><strong>7zip</strong></a>
+                            </li>
+                            <li className="list-none ml-4">or a similar application</li>
+                            <li>64-bit builds don't run on 32-bit systems</li>
+                          </BulletListInside>
+                        </div>
+                        <div>
+                          <SectionTitle>Misc Downloads</SectionTitle>
+                          <BulletListInside>
+                            <li>Alternative download links:
+                              <a href='https://mega.nz/folder/k9MW1KiZ#UOKzjh3IQ0GEgjQ6GUc7ug/folder/B19HAa7Z' target={'_blank'} rel='noreferrer'><strong>&nbsp;here</strong></a>
+                            </li>
+                            <li>Download older UPBGE versions:</li>
+                            <li className="list-none ml-4">
+                              <a href='https://github.com/UPBGE/upbge/releases' target={'_blank'} rel='noreferrer'><strong>&nbsp;here&nbsp;</strong></a>or
+                              <a href='https://mega.nz/folder/k9MW1KiZ#UOKzjh3IQ0GEgjQ6GUc7ug' target={'_blank'} rel='noreferrer'><strong>&nbsp;here&nbsp;</strong></a>
+                            </li>
+                          </BulletListInside>
+                        </div>
+                      </TabSection>
+                    </TabPanel>
+                    <TabPanel>
+                      <TabSection>
+                        <div>
+                          <SectionTitle>Linux x64</SectionTitle>
+                          <Button
+                            href={'https://github.com/UPBGE/upbge/releases/download/v0.2.5b/UPBGEv0.2.5b-b2.79Linux64.tar.xz'}
+                            target={'_blank'}>Download (64-bit)
+                          </Button>
+                        </div>
+                        <div>
+                        <SectionTitle>Linux aarch64 (coming soon)</SectionTitle>
+                        <Button
+                          href={'#'}
+                          target={'_blank'}>Unavailable
+                        </Button>
+                        </div>
+                        <div>
+                          <SectionTitle>Requirements</SectionTitle>
+                          <BulletListInside>
+                            <li>Blender 2.79 runs on all systems that support</li>
+                            <li className="list-none ml-4">OpenGL 2.1 and above, with recent</li>
+                            <li className="list-none ml-4">graphics drivers. For macOS, version 10.9 and later are supported.</li>
+                          </BulletListInside>
+                        </div>
+                        <div>
+                          <SectionTitle>Note</SectionTitle>
+                          <BulletListInside>
+                            <li>Builds are compiled from a CentOS 7</li>
+                            <li className="list-none ml-4">distribution&nbsp;</li>
+                            <li>xz extension can be extracted with&nbsp;
+                              <a href='https://www.7-zip.org/' target={'_blank'} rel='noreferrer'><strong>7zip</strong></a>
+                            </li>
+                            <li className="list-none ml-4">or a similar application</li>
+                            <li>64-bit builds don't run on 32-bit systems</li>
+                          </BulletListInside>
+                        </div>
+                        <div>
+                          <SectionTitle>Misc Downloads</SectionTitle>
+                          <BulletListInside>
+                            <li>Alternative download links:
+                              <a href='https://mega.nz/folder/k9MW1KiZ#UOKzjh3IQ0GEgjQ6GUc7ug/folder/B19HAa7Z' target={'_blank'} rel='noreferrer'><strong>&nbsp;here</strong></a>
+                            </li>
+                            <li>Download older UPBGE versions:</li>
+                            <li className="list-none ml-4">
+                              <a href='https://github.com/UPBGE/upbge/releases' target={'_blank'} rel='noreferrer'><strong>&nbsp;here&nbsp;</strong></a>or
+                              <a href='https://mega.nz/folder/k9MW1KiZ#UOKzjh3IQ0GEgjQ6GUc7ug' target={'_blank'} rel='noreferrer'><strong>&nbsp;here&nbsp;</strong></a>
+                            </li>
+                          </BulletListInside>
+                        </div>
+                      </TabSection>
+                    </TabPanel>
+                    <TabPanel>
+                      <TabSection>
+                        <div>
+                          <SectionTitle>macOS Intel</SectionTitle>
+                          <Button
+                            href={'https://github.com/UPBGE/upbge/releases/download/v0.2.5b/UPBGEv0.2.5b-b2.79MacOS.zip'}
+                            target={'_blank'}>Download (64-bit)
+                          </Button>
+                        </div>
+                        <div>
+                          <SectionTitle>Requirements</SectionTitle>
+                          <BulletListInside>
+                            <li>Blender 2.79 runs on all systems that support</li>
+                            <li className="list-none ml-4">OpenGL 2.1 and above, with recent</li>
+                            <li className="list-none ml-4">graphics drivers. For macOS, version 10.9 and later are supported.</li>
+                          </BulletListInside>
+                        </div>
+                        <div>
+                          <SectionTitle>Note</SectionTitle>
+                          <BulletListInside>
+                            <li>macOS Intel requires version 10+</li>
+                            <li>macOS Apple Silicon requires version 11+</li>
+                            <li>dmg extension can be extracted with&nbsp;
+                              <a href='https://www.7-zip.org/' target={'_blank'} rel='noreferrer'><strong>7zip</strong></a>
+                            </li>
+                            <li className="list-none ml-4">or a similar application</li>
+                          </BulletListInside>
+                        </div>
+                        <div>
+                          <SectionTitle>Misc Downloads</SectionTitle>
+                          <BulletListInside>
+                            <li>Alternative download links:
+                              <a href='https://mega.nz/folder/k9MW1KiZ#UOKzjh3IQ0GEgjQ6GUc7ug/folder/B19HAa7Z' target={'_blank'} rel='noreferrer'><strong>&nbsp;here</strong></a>
+                            </li>
+                            <li>Download older UPBGE versions:</li>
+                            <li className="list-none ml-4">
+                              <a href='https://github.com/UPBGE/upbge/releases' target={'_blank'} rel='noreferrer'><strong>&nbsp;here&nbsp;</strong></a>or
+                              <a href='https://mega.nz/folder/k9MW1KiZ#UOKzjh3IQ0GEgjQ6GUc7ug' target={'_blank'} rel='noreferrer'><strong>&nbsp;here&nbsp;</strong></a>
+                            </li>
+                          </BulletListInside>
+                        </div>
+                      </TabSection>
+                    </TabPanel>
+                    <TabPanel>
+                      <TabSection>
+                        <div>
+                          <SectionTitle>Misc Experimental</SectionTitle>
+                          <Button
+                            href={'https://mega.nz/folder/k9MW1KiZ#UOKzjh3IQ0GEgjQ6GUc7ug/folder/QsVFVIRb'}
+                            target={'_blank'}>Browse or download
+                          </Button>
+                        </div>
+                        <div>
+                          <SectionTitle>Requirements</SectionTitle>
+                          <BulletListInside>
+                            <li>Check in corresponding platform tabs</li>
+                          </BulletListInside>
+                        </div>
+                        <div>
+                          <SectionTitle>Note</SectionTitle>
+                          <BulletListInside>
+                            <li>The repository is hosted inside a external</li>
+                            <li className="list-none ml-4">MEGA folder</li>
+                          </BulletListInside>
+                        </div>
+                      </TabSection>
+                    </TabPanel>
+                  </TabSection>
+                </Tabs>
               </TabPanel>
             </Tabs>
           </div>

--- a/src/pages/Features.js
+++ b/src/pages/Features.js
@@ -32,7 +32,7 @@ const Features = () => {
               <br />
               Thanks to this integration we have:
             </p>
-            <BulletList>
+            <BulletListInside>
               <li>
                 No need for an import-export pipeline. Since Blender supports 3D
                 modelling, sculpting and UV mapping, everything made in the
@@ -53,13 +53,12 @@ const Features = () => {
                 editors, panels and nodes follow the same conventions and
                 standards as Blender itself.
               </li>
-            </BulletList>
+            </BulletListInside>
           </div>
           <div className={'md:order-first mt-5'}>
             <img src={features_1} alt={'UPBGE Screenshot #1'} />
           </div>
         </WideHSection>
-
         <WideHSection>
           <div>
             <SectionTitle>Graphics</SectionTitle>
@@ -72,7 +71,7 @@ const Features = () => {
               <br />
               It has advanced features such as:
             </p>
-            <BulletList>
+            <BulletListInside>
               <li>Physically-based rendering with TAA and SMAA.</li>
               <li>Principled BSDF.</li>
               <li>Environment lighting and HDRIs.</li>
@@ -85,13 +84,12 @@ const Features = () => {
                 Great color management, including HDR, tone mapping, exposure
                 and color transformations such as Filmic.
               </li>
-            </BulletList>
+            </BulletListInside>
           </div>
           <div>
             <img src={features_2} alt={'UPBGE Screenshot #2'} />
           </div>
         </WideHSection>
-
         <WideHSection>
           <div>
             <SectionTitle>Scripting & Logic Support</SectionTitle>
@@ -102,35 +100,37 @@ const Features = () => {
               develop game logic, although there are 3 additional and complete
               methods that the game developer can use:
             </p>
-            <BulletList>
+            <BulletListInside>
               <br />
               <li>
-                <p>The Logic Bricks system.</p> This system is a well tested
+                <strong>The Logic Bricks System</strong><br />
+                This system is a well tested
                 system (around 20 years) and its main advantages are its speed
                 and ease of use. No programming knowledge is required to use
                 them.
               </li>
               <li>
-                <p>The Logic Nodes system.</p> This system is a Visual Scripting
+                <strong>The Logic Nodes System</strong><br />
+                This system is a Visual Scripting
                 system developed atop the UPBGE node interface to create
                 gameplay elements inside UPBGE editor. Its main advantages are
                 its versatility and ease of use. No programming knowledge is
                 required to use them.
               </li>
               <li>
-                <p>The Python Components system.</p> Basically the Python
+                <strong>The Python Components System</strong><br />
+                Basically the Python
                 Components are modules that can be attached to game objects.
                 Each one serves a specific purpose. No programming knowledge is
                 required to use them, although such knowledge is necessary for
                 the development of new or custom components.
               </li>
-            </BulletList>
+            </BulletListInside>
           </div>
           <div className={'md:order-first mt-24'}>
             <img src={features_3} alt={'UPBGE Screenshot #1'} />
           </div>
         </WideHSection>
-
         <WideHSection>
           <div>
             <SectionTitle>Animation System</SectionTitle>
@@ -145,7 +145,6 @@ const Features = () => {
               different node properties of both materials and geometry node
               trees. Even grease pencil objects can be animated.
             </p>
-
             <p>
               <br />
               To make animations, the developer can use any of the following
@@ -171,7 +170,6 @@ const Features = () => {
             </Video>
           </div>
         </WideHSection>
-
         <Section className={'max-w-7xl'}>
           <div className={'grid grid-cols-1 lg:grid-cols-3 gap-x-2 gap-y-4'}>
             <GridSection>
@@ -190,7 +188,6 @@ const Features = () => {
                 static objects and a kinematic character controller.
               </p>
             </GridSection>
-
             <GridSection>
               <GridSectionTitle>OpenXR</GridSectionTitle>
               <p>
@@ -205,12 +202,11 @@ const Features = () => {
                 requires some set up steps.
               </p>
             </GridSection>
-
             <GridSection>
               <GridSectionTitle>Multiplatform Editor</GridSectionTitle>
               <p>
-                The UPBGE editor works in 64-bit on Windows (7, 8, 10, & 11), Linux (x64 and arm), and macOS
-                (x64 and arm) and it has a small size
+                The UPBGE editor works in 64-bit on Windows (7, 8, 10, & 11), Linux (x64 & arm), and macOS
+                (x64 & arm) and it has a small size
                 (around 170MB).
               </p>
               <p>
@@ -219,7 +215,6 @@ const Features = () => {
                 downloaded through an easy to use script).
               </p>
             </GridSection>
-
             <GridSection>
               <GridSectionTitle>Navigation System</GridSectionTitle>
               <p>
@@ -232,7 +227,6 @@ const Features = () => {
                 many cases and comes with a navmesh generation toolset.
               </p>
             </GridSection>
-
             <GridSection>
               <GridSectionTitle>Audio System</GridSectionTitle>
               <p>
@@ -246,7 +240,6 @@ const Features = () => {
                 effects like delay, reverse or fading.
               </p>
             </GridSection>
-
             <GridSection>
               <GridSectionTitle>Multiplatform Deployment</GridSectionTitle>
               <p>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/69180012/154595896-a9e786b6-c39b-4b6f-b0a3-84d150545f35.png)

We can co-author the commit ExxiL if you'd like.

Preview: https://rpaladin.github.io/#/download

Many links created/changed but I think I got them decently correct.

Edit 1:
Maybe remove the UPBGE 0.2.x Linux aarch64 coming soon link since UPBGE 0.2.x development is moot.

Edit 2:
Is UPBGE 0.3.1 the new Stable release instead of UPBGE 0.3.0?