### PR TITLE
Fix the navigation problem on clicking search hits

### DIFF
--- a/src/docs/EmbedSphinx.js
+++ b/src/docs/EmbedSphinx.js
@@ -143,6 +143,10 @@ const EmbedSphinx = () => {
   )
 
   useEffect(() => {
+    setQuery(null)
+  }, [url])
+
+  useEffect(() => {
     document.getElementById('doc-content').scrollTop = 0
   }, [content, query, error])
 


### PR DESCRIPTION
This should fix the problem with the search result page not refreshing the content when clicking on links.

@rpaladin Could you test if it's working as expected? Thanks!