### PR TITLE
Updated current development version on Downloads page to 0.43

### DIFF
--- a/src/pages/Download.js
+++ b/src/pages/Download.js
@@ -55,15 +55,15 @@ const Download = () => {
               <br />
             </div>
             <SectionTitle>Development Release</SectionTitle>
-            <p>Version UPBGE 0.42 Alpha</p>
+            <p>Version UPBGE 0.43 Alpha</p>
             <p>Released a new build each week</p>
             <p>&nbsp;</p>
             <TabSection>
               <div>
                 <BulletListInside>
                   <li>
-                    <strong>UPBGE 0.42 Alpha</strong>&nbsp;is based on &nbsp;
-                    <strong>Blender 4.2</strong>&nbsp;source
+                    <strong>UPBGE 0.43 Alpha</strong>&nbsp;is based on &nbsp;
+                    <strong>Blender 4.3</strong>&nbsp;source
                   </li>
                 </BulletListInside>
               </div>


### PR DESCRIPTION
The Downloads page says the current Development version is 0.42, so I updated it.
